### PR TITLE
fix(ci): use PAT as github token for semantic release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,5 +53,5 @@ jobs:
           node-version: 16
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_SEMANTIC_RELEASE }}
         run: npx semantic-release


### PR DESCRIPTION
* Use PAT in the semantic release CI workflow to trigger release workflow