### PR TITLE
feat: add support for enabled logging strategies

### DIFF
--- a/awsmt/data_source_playback_configuration.go
+++ b/awsmt/data_source_playback_configuration.go
@@ -76,6 +76,10 @@ func (d *dataSourcePlaybackConfiguration) Schema(_ context.Context, _ datasource
 				},
 			},
 			"log_configuration_percent_enabled": computedInt64,
+			"log_configuration_enabled_logging_strategies": schema.ListAttribute{
+				Computed: true,
+				ElementType: types.StringType,
+			},
 			"manifest_processing_rules": schema.SingleNestedAttribute{
 				Computed: true,
 

--- a/awsmt/data_source_playback_configuration_test.go
+++ b/awsmt/data_source_playback_configuration_test.go
@@ -36,7 +36,9 @@ func TestAccPlaybackConfigurationDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "dev"),
 					resource.TestCheckResourceAttr(resourceName, "video_content_source_url", "https://exampleurl.com/"),
 					resource.TestCheckResourceAttr(resourceName, "log_configuration_percent_enabled", "0"),
-				),
+                    resource.TestCheckResourceAttrSet(resourceName, "log_configuration_enabled_logging_strategies.#"),
+                    resource.TestCheckResourceAttr(resourceName, "log_configuration_enabled_logging_strategies.0", "LEGACY_CLOUDWATCH"),
+                ),
 			},
 		},
 	})
@@ -94,6 +96,8 @@ func playbackConfigDS() string {
 							slate_ad_url = "https://exampleurl.com/"
   							tags = {"Environment": "dev"}
  	 						video_content_source_url = "https://exampleurl.com/"
+ 	 						log_configuration_percent_enabled = 0
+                            log_configuration_enabled_logging_strategies = ["LEGACY_CLOUDWATCH"]
 						}
 
 						data "awsmt_playback_configuration" "test"{
@@ -140,6 +144,8 @@ func playbackConfigDSError() string {
 							slate_ad_url = "https://exampleurl.com/"
   							tags = {"Environment": "dev"}
  	 						video_content_source_url = "https://exampleurl.com/"
+ 	 						log_configuration_percent_enabled = 0
+                            log_configuration_enabled_logging_strategies = ["LEGACY_CLOUDWATCH"]
 						}
 
 						data "awsmt_playback_configuration" "test"{

--- a/awsmt/models/models_playback_configuration.go
+++ b/awsmt/models/models_playback_configuration.go
@@ -14,19 +14,20 @@ type PlaybackConfigurationModel struct {
 	// Context: The Provider Framework does not allow computed blocks
 	// Decision: We decided to flatten the Log Configuration and the HLS Configuration blocks into the resource.
 	// Consequences: The schema of the object differs from that of the SDK.
-	HlsConfigurationManifestEndpointPrefix types.String                   `tfsdk:"hls_configuration_manifest_endpoint_prefix"`
-	LogConfigurationPercentEnabled         types.Int64                    `tfsdk:"log_configuration_percent_enabled"`
-	LivePreRollConfiguration               *LivePreRollConfigurationModel `tfsdk:"live_pre_roll_configuration"`
-	ManifestProcessingRules                *ManifestProcessingRulesModel  `tfsdk:"manifest_processing_rules"`
-	Name                                   *string                        `tfsdk:"name"`
-	PersonalizationThresholdSeconds        *int32                         `tfsdk:"personalization_threshold_seconds"`
-	PlaybackConfigurationArn               types.String                   `tfsdk:"playback_configuration_arn"`
-	PlaybackEndpointPrefix                 types.String                   `tfsdk:"playback_endpoint_prefix"`
-	SessionInitializationEndpointPrefix    types.String                   `tfsdk:"session_initialization_endpoint_prefix"`
-	SlateAdUrl                             *string                        `tfsdk:"slate_ad_url"`
-	Tags                                   map[string]string              `tfsdk:"tags"`
-	TranscodeProfileName                   *string                        `tfsdk:"transcode_profile_name"`
-	VideoContentSourceUrl                  *string                        `tfsdk:"video_content_source_url"`
+	HlsConfigurationManifestEndpointPrefix      types.String                    `tfsdk:"hls_configuration_manifest_endpoint_prefix"`
+	LogConfigurationPercentEnabled              types.Int64                     `tfsdk:"log_configuration_percent_enabled"`
+	LogConfigurationEnabledLoggingStrategies    types.List                      `tfsdk:"log_configuration_enabled_logging_strategies"`
+	LivePreRollConfiguration                    *LivePreRollConfigurationModel  `tfsdk:"live_pre_roll_configuration"`
+	ManifestProcessingRules                     *ManifestProcessingRulesModel   `tfsdk:"manifest_processing_rules"`
+	Name                                        *string                         `tfsdk:"name"`
+	PersonalizationThresholdSeconds             *int32                          `tfsdk:"personalization_threshold_seconds"`
+	PlaybackConfigurationArn                    types.String                    `tfsdk:"playback_configuration_arn"`
+	PlaybackEndpointPrefix                      types.String                    `tfsdk:"playback_endpoint_prefix"`
+	SessionInitializationEndpointPrefix         types.String                    `tfsdk:"session_initialization_endpoint_prefix"`
+	SlateAdUrl                                  *string                         `tfsdk:"slate_ad_url"`
+	Tags                                        map[string]string               `tfsdk:"tags"`
+	TranscodeProfileName                        *string                         `tfsdk:"transcode_profile_name"`
+	VideoContentSourceUrl                       *string                         `tfsdk:"video_content_source_url"`
 }
 
 type AvailSuppressionModel struct {

--- a/awsmt/resource_playback_configuration_test.go
+++ b/awsmt/resource_playback_configuration_test.go
@@ -95,8 +95,8 @@ func TestAccPlaybackConfigurationLogPercentage(t *testing.T) {
 	name := "test-acc-playback-configuration-log-percentage"
 	adUrl := "https://www.foo.de/"
 	videoSourceUrl := "https://www.bar.at"
-	p1 := "5"
-	p2 := "8"
+	p1 := 5
+	p2 := 8
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -106,7 +106,7 @@ func TestAccPlaybackConfigurationLogPercentage(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "log_configuration_percent_enabled", p1),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration_percent_enabled", fmt.Sprintf("%d", p1)),
 				),
 			},
 			{
@@ -114,7 +114,41 @@ func TestAccPlaybackConfigurationLogPercentage(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "log_configuration_percent_enabled", p2),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration_percent_enabled", fmt.Sprintf("%d", p2)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPlaybackConfigurationLoggingStrategies(t *testing.T) {
+	resourceName := "awsmt_playback_configuration.r3"
+	name := "test-acc-playback-configuration-enabled-logging-strategies"
+	adUrl := "https://www.foo.de/"
+	videoSourceUrl := "https://www.bar.at"
+	p1 := `["LEGACY_CLOUDWATCH"]`
+	p2 := `["LEGACY_CLOUDWATCH", "VENDED_LOGS"]`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: loggingStrategiesPlaybackConfiguration(name, adUrl, videoSourceUrl, p1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", name),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration_enabled_logging_strategies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration_enabled_logging_strategies.0", "LEGACY_CLOUDWATCH"),
+				),
+			},
+			{
+				Config: loggingStrategiesPlaybackConfiguration(name, adUrl, videoSourceUrl, p2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", name),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration_enabled_logging_strategies.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration_enabled_logging_strategies.0", "LEGACY_CLOUDWATCH"),
+					resource.TestCheckResourceAttr(resourceName, "log_configuration_enabled_logging_strategies.1", "VENDED_LOGS"),
 				),
 			},
 		},
@@ -259,15 +293,27 @@ func configurationAliasesPlaybackConfiguration(name, adUrl, videoSourceUrl, conf
 	)
 }
 
-func logPercentagePlaybackConfiguration(name, adUrl, videoSourceUrl, logPercentage string) string {
+func logPercentagePlaybackConfiguration(name, adUrl, videoSourceUrl string, logPercentage int) string {
 	return fmt.Sprintf(`
 		resource "awsmt_playback_configuration" "r3" {
 			ad_decision_server_url = "%[2]s"
 			name = "%[1]s"
 			video_content_source_url = "%[3]s"
-			log_configuration_percent_enabled = "%[4]s"
+			log_configuration_percent_enabled = %[4]d
 		}
 		`, name, adUrl, videoSourceUrl, logPercentage,
+	)
+}
+
+func loggingStrategiesPlaybackConfiguration(name, adUrl, videoSourceUrl, loggingStrategies string) string {
+	return fmt.Sprintf(`
+		resource "awsmt_playback_configuration" "r3" {
+			ad_decision_server_url = "%[2]s"
+			name = "%[1]s"
+			video_content_source_url = "%[3]s"
+			log_configuration_enabled_logging_strategies = %[4]s
+		}
+		`, name, adUrl, videoSourceUrl, loggingStrategies,
 	)
 }
 

--- a/docs/data-sources/awsmt_playback_configuration.md
+++ b/docs/data-sources/awsmt_playback_configuration.md
@@ -45,6 +45,7 @@ In addition to all arguments above, the following attributes are exported:
   - `max_duration_seconds` - The maximum allowed duration for the pre-roll ad avail.
 - `log_configuration` - The Amazon CloudWatch log settings for a playback configuration.
   - `percent_enabled` - The percentage of session logs that MediaTailor sends to your Cloudwatch Logs account.
+- `log_configuration_enabled_logging_strategies` - The method used for collecting logs from AWS Elemental MediaTailor. Allowed values are "LEGACY_CLOUDWATCH" or "VENDED_LOGS", or both.
 - `manifest_processing_rules` – The configuration for manifest processing rules
   - `ad_marker_passthrough` – For HLS, when set to true, MediaTailor passes through EXT-X-CUE-IN, EXT-X-CUE-OUT, and EXT-X-SPLICEPOINT-SCTE35 ad markers from the origin manifest to the MediaTailor personalized manifest.
     - `enabled` - Enables ad marker passthrough for your configuration.

--- a/docs/resources/awsmt_playback_configuration.md
+++ b/docs/resources/awsmt_playback_configuration.md
@@ -58,6 +58,7 @@ The following arguments are supported:
   - `ad_decision_server_url` - The URL for the ad decision server (ADS) for pre-roll ads.
   - `max_duration_seconds` - The maximum allowed duration for the pre-roll ad avail.
 - `log_configuration_percent_enabled` - The percentage of session logs that MediaTailor sends to your Cloudwatch Logs account.
+- `log_configuration_enabled_logging_strategies` - The method used for collecting logs from AWS Elemental MediaTailor. Allowed values are "LEGACY_CLOUDWATCH" or "VENDED_LOGS", or both.
 - `manifest_processing_rules` – The configuration for manifest processing rules
   - `ad_marker_passthrough` – For HLS, when set to true, MediaTailor passes through EXT-X-CUE-IN, EXT-X-CUE-OUT, and EXT-X-SPLICEPOINT-SCTE35 ad markers from the origin manifest to the MediaTailor personalized manifest.
     - `enabled` - Enables ad marker passthrough for your configuration.

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -3,6 +3,10 @@ terraform {
     awsmt = {
       version = "~> 2.0.0"
       source  = "spring-media/awsmt"
-    }
+     }
   }
+}
+
+provider "awsmt" {
+  region = "eu-central-1"
 }

--- a/examples/playback_configuration.tf
+++ b/examples/playback_configuration.tf
@@ -1,26 +1,39 @@
 resource "awsmt_playback_configuration" "r1" {
   ad_decision_server_url = "https://exampleurl.com/"
   avail_suppression = {
-    mode = "AFTER_LIVE_EDGE"
     fill_policy = "FULL_AVAIL_ONLY"
+    mode        = "BEHIND_LIVE_EDGE"
+    value       = "00:00:00"
+  }
+  bumper = {
+    end_url   = "https://exampleurl.com/"
+    start_url = "https://exampleurl.com/"
   }
   cdn_configuration = {
-    ad_segment_url_prefix = "https://exampleurl.com/"
+    ad_segment_url_prefix      = "https://exampleurl.com/"
+    content_segment_url_prefix = "https://exampleurl.com/"
   }
   dash_configuration = {
-    mpd_location         = "DISABLED",
-    origin_manifest_type = "SINGLE_PERIOD"
+    mpd_location         = "EMT_DEFAULT"
+    origin_manifest_type = "MULTI_PERIOD"
+  }
+  live_pre_roll_configuration = {
+    ad_decision_server_url = "https://exampleurl.com/"
+    max_duration_seconds   = 2
   }
   manifest_processing_rules = {
     ad_marker_passthrough = {
       enabled = "false"
     }
   }
-  log_configuration_percent_enabled = 5
-  name                              = "example-playback-configuration-awsmt"
-  personalization_threshold_seconds = 2
-  tags                              = { "Environment" : "dev" }
-  video_content_source_url          = "https://exampleurl.com/"
+  name                                         = "example-playback-configuration-awsmt"
+  personalization_threshold_seconds            = 2
+  slate_ad_url                                 = "https://exampleurl.com/"
+  tags                                         = { "Environment" : "dev" }
+  video_content_source_url                     = "https://exampleurl.com/"
+  transcode_profile_name                       = "profile_configured_in_your_account"
+  log_configuration_percent_enabled            = 0
+  log_configuration_enabled_logging_strategies = ["LEGACY_CLOUDWATCH", "VENDED_LOGS"]
 }
 
 data "awsmt_playback_configuration" "test" {


### PR DESCRIPTION
Issue #93: Add feature for setting enabled logging strategies.

- Implemented the ability to configure enabled logging strategies.
- Tested with the built-in tests; all playback configuration-related tests passed successfully.
- Updated documentation and example playback_configuration terraform file.
- Ready for review.